### PR TITLE
Fix #14: Remove line references from messages

### DIFF
--- a/module.js
+++ b/module.js
@@ -40,7 +40,8 @@ var parseCSS = function(files, commitUrl, token, cb) {
             }, function(err, res, body) {
                 var addFeature = function(feature) {
                     var diffIndex = parseDiff(feature, file);
-                    renderComment(commentUrl, file.filename, feature.message, diffIndex, token);
+                    var comment = feature.featureData.title + ' not supported by: ' + feature.featureData.missing;
+                    renderComment(commentUrl, file.filename, comment, diffIndex, token);
                 };
                 contents = body;
                 postcss(doiuse({


### PR DESCRIPTION
doiuse compatibility messages start with line references. For example:

    /main.css:22:1: CSS3 selectors not supported by: IE (8)

Users will not need these line references when compatibility comments
appear directly below affected lines, so this commit removes them.