### PR TITLE
Add JSHint requirements, make updates

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+    "browser": true,
+    "node": true,
+
+    "bitwise": true,
+    "curly": true,
+    "eqeqeq": true,
+    "forin": true,
+    "freeze": true,
+    "indent": 4,
+    "noarg": true,
+    "noempty": true,
+    "nonbsp": true,
+    "quotmark": "single",
+    "strict": true,
+    "undef": true,
+    "unused": "vars"
+}

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var express = require('express');
 var app = express();
 var bodyParser = require('body-parser');

--- a/diffParse.js
+++ b/diffParse.js
@@ -1,17 +1,19 @@
+'use strict';
+
 var lineToIndex = function(diff, lineNumber) {
     var diffIndexes = diff.split('\n');
     var currentLine = 0;
     for (var i = 0; i < diffIndexes.length; i++) {
         var currentIndex = diffIndexes[i];
-        if (currentIndex.substring(0, 1) != '-') {
+        if (currentIndex.substring(0, 1) !== '-') {
             currentLine++;
         }
-        if (currentIndex.substring(0, 1) == '@') {
+        if (currentIndex.substring(0, 1) === '@') {
             var work = currentIndex.split('+');
             currentLine = work[1].split(',')[0];
         }
-        if (currentLine == lineNumber) {
-            if (currentIndex.substring(0, 1) == '+') {
+        if (currentLine === lineNumber) {
+            if (currentIndex.substring(0, 1) === '+') {
                 return i + 1; //cause GitHub seems to start file indexes at 1 instead of 0. Oh Well.
             } else {
                 return -1;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
 var beautify = require('gulp-jsbeautifier');

--- a/landingPage.js
+++ b/landingPage.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var marked = require('marked');
 

--- a/module.js
+++ b/module.js
@@ -1,9 +1,11 @@
+'use strict';
+
 var request = require('request');
 var diff = require('./diffParse');
 var postcss = require('postcss');
 var doiuse = require('doiuse');
 var path = require('path');
-var token = "token " + process.env.OAUTH_TOKEN;
+var token = 'token ' + process.env.OAUTH_TOKEN;
 
 var hook = function(req, res) {
     var localToken = token;
@@ -30,7 +32,7 @@ var github = function(payload, localToken) {
 var parseCSS = function(files, commitUrl, token, cb) {
     var commentUrl = commitUrl + '/comments';
     files.forEach(function(file, index) {
-        if (path.extname(file.filename) == '.css') {
+        if (path.extname(file.filename) === '.css') {
             var rawUrl = file.raw_url;
             request({
                 url: rawUrl,
@@ -43,12 +45,12 @@ var parseCSS = function(files, commitUrl, token, cb) {
                     var comment = feature.featureData.title + ' not supported by: ' + feature.featureData.missing;
                     renderComment(commentUrl, file.filename, comment, diffIndex, token);
                 };
-                contents = body;
+                var contents = body;
                 postcss(doiuse({
                     browserSelection: ['ie >= 8', '> 1%'],
                     onFeatureUsage: addFeature
                 })).process(contents, {
-                    from: "/" + file.filename
+                    from: '/' + file.filename
                 }).then(function(res) {
                     //renderComment(commentUrl, commit, featureMessage, 0, token);
                 });
@@ -60,10 +62,10 @@ var parseCSS = function(files, commitUrl, token, cb) {
 var renderComment = function(url, file, comment, position, token) {
     request({
         url: url,
-        method: "POST",
+        method: 'POST',
         headers: {
-            "User-Agent": "github-cleanpr",
-            "Authorization": token
+            'User-Agent': 'github-cleanpr',
+            'Authorization': token
         },
         body: JSON.stringify({
             body: comment,


### PR DESCRIPTION
This enforces the conventions we established on MDN. The more we can
defer to JSHint, the less need to think about style ourselves.